### PR TITLE
Enable H2 Console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea/
 /target/
+*.iml

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+#H2 Database Configuration
+spring.datasource.url=jdbc:h2:mem:surveydb
+spring.h2.console.enabled=true
+#Allow H2 Console access on Heroku
+spring.h2.console.settings.web-allow-others=true
+
+#Show SQL Queries in Logs
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
Description: 

- The H2 Database provides a web interface to see the database state. Seeing the database state will help document the schema and verify the application is saving data correctly. 
- To access the H2 web console navigate to /h2-console and enter "jdbc:h2:mem:surveydb" as the JDBC URL and click connect
- This pull request also adds *iml files to .gitignore and makes SQL logging more verbose

Testing:
- This change does not require associated test cases

closes #25