### PR TITLE
Add Spring Boot Actuator Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target/
 *.iml
 *.DS_Store
+application.log

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,8 @@ spring.h2.console.settings.web-allow-others=true
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 spring.jpa.properties.hibernate.format_sql=true
+
+#Log to file
+logging.file.name=application.log
+#Expose specific actuator endpoints
+management.endpoints.web.exposure.include=env,mappings,logfile


### PR DESCRIPTION
Description:
- Add Spring Boot Actuator to project
- Expose env, mappings and logfile endpoints at the base path /actuator (ex. /actuator/env)
- The env endpoint prints environment variables
- The mappings endpoint prints all RequestMapping paths
- The logfile endpoint prints the logs of the running application instance

Testing:
- Tested that actuator endpoints are accessible

Closes #24 